### PR TITLE
fix: define selectionDebounce and send saveEditedXBlockData

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,14 @@ Unreleased
 **********
 
 *
+0.9.1 – 2026-04-28
+******************
+
+Fixed
+=====
+
+* Define selectionDebounce and send saveEditedXBlockData after updateMaxCountPerCollection (#24)
+
 0.9.0 – 2026-04-22
 ******************
 

--- a/examquestionbank/__init__.py
+++ b/examquestionbank/__init__.py
@@ -4,4 +4,4 @@ Init for the ExamQuestionBankXBlock package.
 
 from .examquestionbank import ExamQuestionBankXBlock
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'

--- a/examquestionbank/static/js/author_view.js
+++ b/examquestionbank/static/js/author_view.js
@@ -2,6 +2,7 @@
 function ExamQuestionBankAuthorView(runtime, element, context) {
     'use strict';
     var $element = $(element);
+    var selectionDebounce;
 
     var refreshButton = $element.find('.btn-refresh-collections');
     var refreshCollectionsUrl = runtime.handlerUrl(element, 'refresh_collections');
@@ -183,6 +184,16 @@ function ExamQuestionBankAuthorView(runtime, element, context) {
 				contentType: 'application/json',
 				dataType: 'json'
 			})
+            .done(function () {
+                var usageId = $element.data("usageId");
+                window.parent.postMessage(
+                    {
+                        type: 'saveEditedXBlockData',
+                        payload: { locator: usageId },
+                    },
+                    '*',
+                );
+            })
 			.fail(function () {
 				runtime.notify('error', {
 					title: gettext('Selection update failed'),


### PR DESCRIPTION
## Description

This PR only defined the "selectionDebounce" variable, needed because we were using 'use strict'.
Also send a saveEditedXBlockData signal when updating MaxCountPerCollection.

Context:
This fixes and improves the behavior in MaxCountPerCollection.

## Screencast and how to test

**How to test:** modify the number of elements to show per collection, and the xblock should change the value inside the xblock configuration, and also show that you need to publish your changes.

### Before

Modify the number of elements shown per collection, and the xblock doesn't update the XBlock info.

[Screencast from 2026-04-27 19-17-47.webm](https://github.com/user-attachments/assets/333799e9-80d5-4459-aac1-9bec66e42ddb)

### After

Modify the number of elements shown per collection, and the xblock updates its value in the xblock configuration, and also shows that you need to publish your changes.

[Screencast from 2026-04-27 19-19-36.webm](https://github.com/user-attachments/assets/0c950912-dda7-4a05-a171-a2a936bdc2ca)


**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated (N/A)
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets